### PR TITLE
Add info about translations

### DIFF
--- a/src/components/Features.astro
+++ b/src/components/Features.astro
@@ -3,7 +3,7 @@ const FEATURES = [
   {
     title: "Organize with Elegance and Efficiency",
     description:
-      "Discover Planify, the native task management application for GNU/Linux. With a minimalist and attractive interface, Planify combines simplicity and functionality so you can focus on what matters. Optimized for performance and ease of use, it enhances your productivity with a hassle-free organization experience. Get organized and achieve more with Planify!",
+      "Discover Planify, the native multilingual task management application for GNU/Linux. With a minimalist and attractive interface, Planify combines simplicity and functionality so you can focus on what matters. Optimized for performance and ease of use, it enhances your productivity with a hassle-free organization experience. Get organized and achieve more with Planify!",
     image: "/features/planify.png",
   },
   {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -27,6 +27,11 @@ const currentYear = new Date().getFullYear();
           class="hover:underline">Contact</a
         >
       </li>
+      <li>
+        <a href="https://hosted.weblate.org/engage/planner/"
+          class="hover:underline">Translations</a
+        >
+      </li>
     </ul>
   </div>
 </footer>


### PR DESCRIPTION
1. By adding the first commit users get the information that the app is translated into other languages.
2. By adding the second commit users can directly access the "Hosted Weblate" translation platform. This is a great way to get users involved into translating the app into their langauges or translate and correct existing languages. Placing this link in the footer is a **one-click action** to go directly to the translation platform. Currently users have to open the "Blog" page and scroll the page to find out about the possibility to translate.